### PR TITLE
Support for multiple rule filters, change api, support commits

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+	"printWidth": 100,
 	"useTabs": true,
 	"semi": false,
 	"trailingComma": "all",

--- a/danger/commitJiraLink.ts
+++ b/danger/commitJiraLink.ts
@@ -1,0 +1,23 @@
+import { Rule } from "../src"
+
+export default function commitJiraLink() {
+	let TICKET_REGEX = /\b(JIRA-\d+)\b/
+	return new Rule({
+		match: {
+			commits: [TICKET_REGEX],
+		},
+		messages: {
+			jiraLink: `
+        [View linked ticket {ticket} on JIRA](https://jira.intranet.corp/{ticket})
+      `,
+		},
+		async run({ commits, context }) {
+			for (let commit of commits) {
+				let match = commit.message.match(TICKET_REGEX)
+				if (match) {
+					context.message("jiraLink", {}, { ticket: match[1] })
+				}
+			}
+		},
+	})
+}

--- a/danger/preferModuleStructure.ts
+++ b/danger/preferModuleStructure.ts
@@ -2,7 +2,9 @@ import { Rule } from "../src"
 
 export default function preferModuleStructure(options: { projectDir: string }) {
 	return new Rule({
-		files: [`${options.projectDir}/**`],
+		match: {
+			files: [`${options.projectDir}/**`],
+		},
 		messages: {
 			foundLegacyFileWithManyChanges: `
         **Consider moving this file to \`@app/modules\`**
@@ -23,7 +25,7 @@ export default function preferModuleStructure(options: { projectDir: string }) {
         the codebase organized.
       `,
 		},
-		async run(files, context) {
+		async run({ files, context }) {
 			let legacyFiles = files.matches(
 				`${options.projectDir}/{actions,stores,components,components_common,components_ios}/**/*`,
 			)
@@ -38,9 +40,7 @@ export default function preferModuleStructure(options: { projectDir: string }) {
 				}
 			}
 
-			let constantFiles = files.matches(
-				`${options.projectDir}/{Constants.tsx,ConstantsIOS.tsx}`,
-			)
+			let constantFiles = files.matches(`${options.projectDir}/{Constants.tsx,ConstantsIOS.tsx}`)
 
 			for (let constantFile of constantFiles.modified) {
 				let diff = constantFile.diff()

--- a/danger/preferTypeScript.ts
+++ b/danger/preferTypeScript.ts
@@ -2,7 +2,9 @@ import { Rule } from "../src"
 
 export default function preferTypeScript() {
 	return new Rule({
-		files: ["**/*.{js,jsx,ts,tsx}", "**"],
+		match: {
+			files: ["**/*.{js,jsx,ts,tsx}", "**"],
+		},
 		messages: {
 			foundNewJSFile: `
 				**Use TypeScript for new code files**
@@ -30,7 +32,7 @@ export default function preferTypeScript() {
 				Migrate Flow-typed JavaScript files to TypeScript
 			`,
 		},
-		async run(files, context) {
+		async run({ files, context }) {
 			for (let file of files.touched) {
 				if (file.matches("*.{js,jsx}")) {
 					if (file.created) {
@@ -42,9 +44,7 @@ export default function preferTypeScript() {
 							} else {
 								context.warn("foundChangedFlowFile", { file })
 							}
-						} else if (
-							await file.diff().changedBy({ added: 0.1, removed: 0.5 })
-						) {
+						} else if (await file.diff().changedBy({ added: 0.1, removed: 0.5 })) {
 							context.warn("foundJSFileWithManyChanges", { file })
 						}
 					}

--- a/danger/recommendStoreV2.ts
+++ b/danger/recommendStoreV2.ts
@@ -2,7 +2,9 @@ import { Rule } from "../src"
 
 export default function recommendStoreV2() {
 	return new Rule({
-		files: ["android_app/**/Store*.kt"],
+		match: {
+			files: ["android_app/**/Store*.kt"],
+		},
 		messages: {
 			foundLegacyStoreWithManyChanges: `
         **Found a legacy store with many changes**
@@ -10,7 +12,7 @@ export default function recommendStoreV2() {
         Please consider migrating this to the new StoreV2 architecture.
       `,
 		},
-		async run(files, context) {
+		async run({ files, context }) {
 			for (let file of files.modified) {
 				if (await file.diff().changedBy({ added: 0.1, removed: 0.3 })) {
 					if (!(await file.contains("StoreV2"))) {

--- a/danger/recommendStorybookExamples.ts
+++ b/danger/recommendStorybookExamples.ts
@@ -42,7 +42,9 @@ export default function recommendStorybookExamples(options: {
 	let componentPattern = `${options.componentDir}/**/*.tsx`
 	let storybookPattern = `${options.storybookDir}/**/*.tsx`
 	return new Rule({
-		files: [componentPattern, storybookPattern],
+		match: {
+			files: [componentPattern, storybookPattern],
+		},
 		messages: {
 			foundNewComponentWithoutStory: `
 				Please add a story for new components
@@ -52,7 +54,7 @@ export default function recommendStorybookExamples(options: {
 				it has a corresponding story?
 			`,
 		},
-		async run(files, context) {
+		async run({ files, context }) {
 			let components = files.matches(componentPattern).edited
 			let storybooks = files.matches(storybookPattern).all
 

--- a/danger/todoComments.ts
+++ b/danger/todoComments.ts
@@ -2,7 +2,9 @@ import { Rule } from "../src"
 
 export default function todoComments() {
 	return new Rule({
-		files: ["**/*.{js,ts,tsx}"],
+		match: {
+			files: ["**/*.{js,ts,tsx}"],
+		},
 		messages: {
 			fixTodoComment: `
         Reminder: There's a TODO comment nearby some code you changed. If you
@@ -11,7 +13,7 @@ export default function todoComments() {
         address it as part of your PR?
       `,
 		},
-		async run(files, context) {
+		async run({ files, context }) {
 			for (let file of files.matches("src/Diff.ts").all) {
 				let lines = await file.diff().unified()
 

--- a/danger/todoComments.ts
+++ b/danger/todoComments.ts
@@ -14,7 +14,7 @@ export default function todoComments() {
       `,
 		},
 		async run({ files, context }) {
-			for (let file of files.matches("src/Diff.ts").all) {
+			for (let file of files.edited) {
 				let lines = await file.diff().unified()
 
 				for (let line of lines) {

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -4,6 +4,7 @@ import recommendStoreV2 from "./danger/recommendStoreV2"
 import recommendStorybookExamples from "./danger/recommendStorybookExamples"
 import preferModuleStructure from "./danger/preferModuleStructure"
 import todoComments from "./danger/todoComments"
+import commitJiraLink from "./danger/commitJiraLink"
 
 run(
 	// Please add rules in alphabetical order
@@ -21,4 +22,5 @@ run(
 		projectDir: "app",
 	}),
 	todoComments(),
+	commitJiraLink(),
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -2321,6 +2321,11 @@
         "@octokit/rest": "^16.43.1"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memoizee": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "execa": "^5.0.0",
     "intl-messageformat": "^9.3.19",
+    "memoize-one": "^5.1.1",
     "yaml": "^1.10.0"
   },
   "peerDependencies": {

--- a/src/Bytes.ts
+++ b/src/Bytes.ts
@@ -1,5 +1,5 @@
 import type { Reader } from "./types"
-import contains from "./utils/contains"
+import contains, { Matcher } from "./utils/contains"
 
 export default class Bytes {
 	private _reader: Reader
@@ -19,7 +19,7 @@ export default class Bytes {
 	/**
 	 * Does this file/diff/etc contain a string or match a regex?
 	 */
-	async contains(matcher: string | RegExp): Promise<boolean> {
+	async contains(matcher: Matcher): Promise<boolean> {
 		let contents = await this.contents()
 		return contains(contents, matcher)
 	}

--- a/src/Commit.ts
+++ b/src/Commit.ts
@@ -1,0 +1,38 @@
+import type { GitCommit } from "danger"
+import contains, { Matcher } from "./utils/contains"
+
+export default class Commit {
+	private _commit: GitCommit
+
+	constructor(commit: GitCommit) {
+		this._commit = commit
+	}
+
+	/**
+	 * Get the commit's SHA
+	 */
+	get sha(): string {
+		return this._commit.sha
+	}
+
+	/**
+	 * Get the commit's parents' SHA's.
+	 */
+	get parents(): string[] | null {
+		return this._commit.parents ?? null
+	}
+
+	/**
+	 * Get the commit message
+	 */
+	get message(): string {
+		return this._commit.message
+	}
+
+	/**
+	 * Does this commit have a message containing a string or matching a regex?
+	 */
+	contains(matcher: Matcher): boolean {
+		return contains(this.message, matcher)
+	}
+}

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -15,7 +15,7 @@ export default class Context<M extends Messages> {
 		this._reporter("fail", messageId, location, values)
 	}
 
-	message(messageId: string, location: ReportLocation = {}, values: Values = {}): void {
+	message(messageId: keyof M, location: ReportLocation = {}, values: Values = {}): void {
 		this._reporter("message", messageId, location, values)
 	}
 }

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,5 +1,4 @@
 import type { Messages, Reporter, ReportLocation, Values } from "./types"
-import Line from "./Line"
 
 export default class Context<M extends Messages> {
 	private _reporter: Reporter<M>
@@ -8,27 +7,15 @@ export default class Context<M extends Messages> {
 		this._reporter = reporter
 	}
 
-	warn(
-		messageId: keyof M,
-		location: ReportLocation = {},
-		values: Values = {},
-	): void {
+	warn(messageId: keyof M, location: ReportLocation = {}, values: Values = {}): void {
 		this._reporter("warn", messageId, location, values)
 	}
 
-	fail(
-		messageId: keyof M,
-		location: ReportLocation = {},
-		values: Values = {},
-	): void {
+	fail(messageId: keyof M, location: ReportLocation = {}, values: Values = {}): void {
 		this._reporter("fail", messageId, location, values)
 	}
 
-	message(
-		messageId: string,
-		location: ReportLocation = {},
-		values: Values = {},
-	): void {
+	message(messageId: string, location: ReportLocation = {}, values: Values = {}): void {
 		this._reporter("message", messageId, location, values)
 	}
 }

--- a/src/Rule.ts
+++ b/src/Rule.ts
@@ -1,19 +1,20 @@
-import type Files from "./Files"
-import type Context from "./Context"
-import type { Messages } from "./types"
+import type { Messages, RuleMatchers, RuleValues } from "./types"
 
-export interface RuleOptions<M extends Messages> {
-	files: string[]
+export interface RuleOptions<M extends Messages, F extends RuleMatchers> {
+	match: F
 	messages: M
-	run(files: Files, context: Context<M>): Promise<void> | void
+	run(values: RuleValues<M, F>): Promise<void> | void
 }
 
-export default class Rule<M extends Messages> implements RuleOptions<M> {
-	files: string[]
+export default class Rule<M extends Messages, F extends RuleMatchers> implements RuleOptions<M, F> {
+	match: F
 	messages: M
-	run: (files: Files, context: Context<M>) => Promise<void> | void
-	constructor(options: RuleOptions<M>) {
-		this.files = options.files
+	run: (values: RuleValues<M, F>) => Promise<void> | void
+	constructor(options: RuleOptions<M, F>) {
+		if (Object.keys(options.match).length === 0) {
+			throw new Error("Your rule must have at least one filter")
+		}
+		this.match = options.match
 		this.messages = options.messages
 		this.run = options.run
 	}

--- a/src/RuleFilter.ts
+++ b/src/RuleFilter.ts
@@ -1,0 +1,81 @@
+import type Context from "./Context"
+import type { RuleMatchers, RuleValues } from "./types"
+
+export interface FilterOptions<Key extends keyof RuleMatchers> {
+	matches(matcher: NonNullable<RuleMatchers[Key]>): Promise<boolean>
+	build(matcher: NonNullable<RuleMatchers[Key]>): Promise<NonNullable<RuleValues<any, any>[Key]>>
+}
+
+type RuleValue<Key extends keyof RuleMatchers> = RuleValues<any, any>[Key]
+
+export type RuleFiltersMap = {
+	[Key in NonNullable<keyof RuleMatchers>]: RuleFilter<Key>
+}
+
+export default class RuleFilter<Key extends keyof RuleMatchers> {
+	_options: FilterOptions<Key>
+
+	constructor(options: FilterOptions<Key>) {
+		this._options = options
+	}
+
+	/**
+	 * Runs the filter's matches() function.
+	 */
+	async matches(matcher: RuleMatchers[Key]): Promise<boolean> {
+		if (matcher == null) {
+			return false
+		}
+
+		if (Array.isArray(matcher) && matcher.length === 0) {
+			throw new Error("Filters cannot be empty arrays")
+		}
+
+		return this._options.matches(matcher!)
+	}
+
+	/**
+	 * Runs the filter's build() function.
+	 */
+	async build(matcher: RuleMatchers[Key]): Promise<RuleValue<Key>> {
+		if (matcher == null) {
+			return null
+		}
+
+		if (Array.isArray(matcher) && matcher.length === 0) {
+			throw new Error("Filters cannot be empty arrays")
+		}
+
+		return this._options.build(matcher!)
+	}
+
+	/**
+	 * Do any of the rule filters match?
+	 */
+	static async any(ruleFiltersMap: RuleFiltersMap, ruleMatchers: RuleMatchers): Promise<boolean> {
+		for (let key of Object.keys(ruleFiltersMap) as (keyof RuleMatchers)[]) {
+			let result = await ruleFiltersMap[key].matches(ruleMatchers[key] as any)
+			if (result) {
+				return true
+			}
+		}
+		return false
+	}
+
+	/**
+	 * Build the RuleValues from filters.
+	 */
+	static async buildRuleValues(
+		ruleFiltersMap: RuleFiltersMap,
+		ruleMatchers: RuleMatchers,
+		context: Context<any>,
+	): Promise<RuleValues<any, any>> {
+		let ruleValues: Partial<RuleValues<any, any>> = { context }
+
+		for (let key of Object.keys(ruleFiltersMap) as (keyof RuleMatchers)[]) {
+			ruleValues[key] = (await ruleFiltersMap[key].build(ruleMatchers[key] as any)) as any
+		}
+
+		return ruleValues as RuleValues<any, any>
+	}
+}

--- a/src/filters/commits.ts
+++ b/src/filters/commits.ts
@@ -1,0 +1,26 @@
+import Commit from "../Commit"
+import RuleFilter from "../RuleFilter"
+import contains from "../utils/contains"
+
+export default function createCommitsFilter() {
+	return new RuleFilter<"commits">({
+		async matches(matchers) {
+			return danger.git.commits.some((commit) => {
+				return matchers.some((matcher) => {
+					return contains(commit.message, matcher)
+				})
+			})
+		},
+		async build(matchers) {
+			return danger.git.commits
+				.filter((commit) => {
+					return matchers.some((matcher) => {
+						return contains(commit.message, matcher)
+					})
+				})
+				.map((commit) => {
+					return new Commit(commit)
+				})
+		},
+	})
+}

--- a/src/filters/files.ts
+++ b/src/filters/files.ts
@@ -1,0 +1,22 @@
+import RuleFilter from "../RuleFilter"
+import matches from "../utils/matches"
+import Files from "../Files"
+import memoizeOne from "memoize-one"
+
+let fileMatch = memoizeOne((matchers: string[]) => {
+	return danger.git.fileMatch(...matchers)
+})
+
+export default function createFilesFilter(allFiles: string[]) {
+	return new RuleFilter<"files">({
+		async matches(matchers) {
+			let filesState = fileMatch(matchers)
+			return filesState.edited || filesState.deleted
+		},
+		async build(matchers) {
+			let filesState = fileMatch(matchers)
+			let matchingFiles = matches(allFiles, matchers)
+			return new Files(matchingFiles, filesState.getKeyedPaths())
+		},
+	})
+}

--- a/src/filters/labels.ts
+++ b/src/filters/labels.ts
@@ -1,0 +1,12 @@
+// import RuleFilter from "../RuleFilter"
+
+// export default function createLabelsFilter() {
+// 	return new RuleFilter<"labels">({
+// 		async matches(matcher) {
+// 			return false
+// 		},
+// 		async build(matcher) {
+// 			return []
+// 		},
+// 	})
+// }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import type Files from "./Files"
 import type Context from "./Context"
 import type Rule from "./Rule"
 import type Line from "./Line"
+import type Commit from "./Commit"
 
 export interface StructuredDiffBaseChange {
 	type: "add" | "del" | "normal"
@@ -89,7 +90,7 @@ export interface ReportLocation {
 
 export interface Report {
 	kind: ReportKind
-	rule: Rule<Messages>
+	rule: Rule<Messages, RuleMatchers>
 	messageId: string
 	locations: ReportLocation[]
 	values?: Values
@@ -104,6 +105,12 @@ export type Reporter<M extends Messages> = (
 
 export type Reader = () => Promise<string> | string
 
+export interface RuleMatchers {
+	files?: string[]
+	commits?: (string | RegExp)[]
+	// labels?: (string | RegExp)[]
+}
+
 export interface Messages {
 	[key: string]: string
 }
@@ -117,6 +124,13 @@ export interface RuleOptions<M extends Messages> {
 	helpLink?: string
 	messages: M
 	run(files: Files, context: Context<M>): Promise<void> | void
+}
+
+export interface RuleValues<M extends Messages, F extends RuleMatchers> {
+	files: F["files"] extends NonNullable<RuleMatchers["files"]> ? Files : null
+	commits: F["commits"] extends NonNullable<RuleMatchers["commits"]> ? Commit[] : null
+	// labels: F["labels"] extends NonNullable<RuleMatchers["labels"]> ? unknown[] : null
+	context: Context<M>
 }
 
 declare global {

--- a/src/utils/contains.ts
+++ b/src/utils/contains.ts
@@ -1,7 +1,6 @@
-export default function contains(
-	input: string,
-	matcher: RegExp | string,
-): boolean {
+export type Matcher = RegExp | string
+
+export default function contains(input: string, matcher: Matcher): boolean {
 	if (typeof matcher === "string") {
 		return input.includes(matcher)
 	} else {


### PR DESCRIPTION
This resolves #1 

Breaking changes:

```diff
  return new Rule({
-   files: ["api/routes/*.py"],
+   match: {
+     files: ["api/routes/*.py"],
+   },
    messages: {
      // ...
    },
-   async run(files, context) {
+   async run({ files, context }) {
```

New Features:

```diff
  return new Rule({
    match: {
      files: ["api/routes/*.py"],
+     commits: [/\b(JIRA-\d+)\b/],
    },
    messages: {
      // ...
    },
    async run({
      files,
+     commits,
      context,
    }) {
```

