### PR TITLE
add before/after to lines, remove { line: number } from report methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,10 @@ await file.json() // { ... }
 await file.yaml() // { ... }
 
 // Read this file line by line
-await file.lines() // [Line, Line, Line]
+await file.lines() // [Line (1), Line (2), Line (3)]
+await file.lines({ after: line1 }) // [Line (2), Line (3)]
+await file.lines({ before: line3 }) // [Line (1), Line (2)]
+await file.lines({ after: line1, before: line3 }) // [Line (2)]
 ```
 
 ### `Diff`

--- a/danger/checkAPIEndpointLimits.ts
+++ b/danger/checkAPIEndpointLimits.ts
@@ -1,0 +1,47 @@
+import { Rule } from "../src"
+
+export default function checkAPIEndpointLimits() {
+	return new Rule({
+		match: {
+			files: ["api/**/*.py"],
+		},
+		messages: {
+			loginRequired: `
+				Consider adding @login_required.
+			`,
+			rateLimit: `
+				Strongly consider adding a @rate_limit to protect our backend.
+			`,
+		},
+
+		async run({ files, context }) {
+			for (const file of files.edited) {
+				for (const line of await file.diff().added()) {
+					if (await line.contains("@route")) {
+						let hasRateLimit = false
+						let hasLoginRequired = false
+
+						for (const afterLine of await file.lines({ after: line })) {
+							if (await afterLine.contains(/^def /)) {
+								break
+							}
+							if (await afterLine.contains(/^@rate_limit/)) {
+								hasRateLimit = true
+							}
+							if (await afterLine.contains(/^@login_required/)) {
+								hasLoginRequired = true
+							}
+						}
+
+						if (!hasRateLimit) {
+							context.warn("rateLimit", { file, line })
+						}
+						if (!hasLoginRequired) {
+							context.warn("loginRequired", { file, line })
+						}
+					}
+				}
+			}
+		},
+	})
+}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -5,6 +5,7 @@ import recommendStorybookExamples from "./danger/recommendStorybookExamples"
 import preferModuleStructure from "./danger/preferModuleStructure"
 import todoComments from "./danger/todoComments"
 import commitJiraLink from "./danger/commitJiraLink"
+import checkAPIEndpointLimits from "./danger/checkAPIEndpointLimits"
 
 run(
 	// Please add rules in alphabetical order
@@ -23,4 +24,5 @@ run(
 	}),
 	todoComments(),
 	commitJiraLink(),
+	checkAPIEndpointLimits(),
 )

--- a/src/FileState.ts
+++ b/src/FileState.ts
@@ -5,6 +5,11 @@ import Bytes from "./Bytes"
 import Line from "./Line"
 import type { Reader } from "./types"
 
+export interface LinesOptions {
+	after?: Line
+	before?: Line
+}
+
 export default class FileState extends Bytes {
 	private _filePath: string
 
@@ -72,9 +77,21 @@ export default class FileState extends Bytes {
 	/**
 	 * Read this file line by line
 	 */
-	async lines(): Promise<Line[]> {
+	async lines(options: LinesOptions = {}): Promise<Line[]> {
+		let afterIndex: number | undefined
+		let beforeIndex: number | undefined
+
+		if (options.after) {
+			afterIndex = options.after.lineNumber
+		}
+		if (options.before) {
+			beforeIndex = options.before.lineNumber - 2
+		}
+
 		let contents = await this.contents()
-		return contents.split("\n").map((line, index) => {
+		let rawLines = contents.split("\n").slice(afterIndex, beforeIndex)
+
+		return rawLines.map((line, index) => {
 			return new Line(index + 1, () => line)
 		})
 	}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,5 @@
 import Rule from "./Rule"
 import Context from "./Context"
-import Line from "./Line"
 import type { Report, Messages, RuleMatchers } from "./types"
 import formatReport from "./utils/formatReport"
 import execStdout from "./utils/execStdout"
@@ -8,10 +7,6 @@ import createFilesFilter from "./filters/files"
 // import createLabelsFilter from "./filters/labels"
 import createCommitsFilter from "./filters/commits"
 import RuleFilter, { RuleFiltersMap } from "./RuleFilter"
-
-function getLineNumber(line: Line | number | undefined): number | undefined {
-	return line instanceof Line ? line.lineNumber : line
-}
 
 async function getAllFiles() {
 	let stdout = await execStdout("git", ["ls-tree", "--name-only", "-r", danger.git.head])
@@ -61,7 +56,7 @@ async function _run(rules: Rule<Messages, RuleMatchers>[]) {
 		let msg = formatReport(report)
 
 		let file = report.location.file?.path
-		let line = getLineNumber(report.location.line)
+		let line = report.location.line?.lineNumber
 
 		if (report.kind === "fail") {
 			fail(msg, file, line)

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export type ReportKind = "warn" | "fail" | "message"
 
 export interface ReportLocation {
 	file?: File
-	line?: number | Line
+	line?: Line
 }
 
 export interface Report {


### PR DESCRIPTION
## Added: (Feature)

```js
file.lines() // [Line (1), Line (2), Line (3)]
file.lines({ after: line1 }) // [Line (2), Line (3)]
file.lines({ before: line3 }) // [Line (1), Line (2)]
file.lines({ after: line1, before: line3 }) // [Line (2)]
```

## Removed: (Breaking Change)

This was causing bugs as people don't expect line numbers to be one-indexed, better to manage everything internally

```js
context.warn("msg", { file, line: 42 })
```