### PR TITLE
init diffline

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,20 +292,44 @@ await file.lines({ before: line3 }) // [Line (1), Line (2)]
 await file.lines({ after: line1, before: line3 }) // [Line (2)]
 ```
 
+### `DiffLine`
+
+> (extends [`Bytes`](#bytes))
+
+```ts
+// Has this diff line's content been addedd?
+diffLine.added // true | false
+
+// Has this diff line's content been removed?
+diffLine.removed // true | false
+
+// Has this diff line's content been changed (added or removed)?
+diffLine.changed // true | false
+
+// Is this diff line's content unchanged?
+diffLine.unchanged // true | false
+
+// What is the line number before the change?
+diffLine.lineNumberBefore // number | null
+
+// What is the line number after the change?
+diffLine.lineNumberAfter // number | null
+```
+
 ### `Diff`
 
 ```ts
 // Only the added lines
-await diff.added() // [Line, Line, Line]
+await diff.added() // [DiffLine, DiffLine]
 
 // Only the removed lines
-await diff.removed() // [Line, Line, Line]
+await diff.removed() // [DiffLine, DiffLine]
 
 // All of the changed lines
-await diff.changed() // [Line, Line, Line, Line, Line, Line]
+await diff.changed() // [DiffLine, DiffLine, DiffLine, DiffLine]
 
 // All of the changed lines with several lines of surrounding context
-await diff.unified()
+await diff.unified() // [DiffLine, DiffLine, DiffLine, DiffLine, DiffLine, ...]
 
 // Returns a JSONDiff of the file (assuming the file is JSON)
 await diff.jsonDiff() // JSONDiff { ... }

--- a/danger/todoComments.ts
+++ b/danger/todoComments.ts
@@ -15,13 +15,18 @@ export default function todoComments() {
 		},
 		async run({ files, context }) {
 			for (let file of files.modifiedOrCreated) {
-				let lines = await file.diff().unified()
+				let diffLines = await file.diff().unified()
 
-				for (let line of lines) {
+				for (let diffLine of diffLines) {
+					// Skip deleted lines
+					if (diffLine.removed) {
+						continue
+					}
+
 					// Regex is close enough for our purposes since this is just a
 					// warning on only the changed+nearby lines
-					if (await line.contains(/\/[\/\*].*\bTODO\b.*/)) {
-						context.warn("fixTodoComment", { file, line })
+					if (await diffLine.contains(/\/[\/\*].*\bTODO\b.*/)) {
+						context.warn("fixTodoComment", { file, line: diffLine })
 					}
 				}
 			}

--- a/src/DiffLine.ts
+++ b/src/DiffLine.ts
@@ -1,0 +1,71 @@
+import Bytes from "./Bytes"
+import type { StructuredDiffChange } from "./types"
+
+function cleanupDiffLines(lines: string) {
+	return lines.replace(/^[\+\- ]/gm, "")
+}
+
+export default class DiffLine extends Bytes {
+	private _change: StructuredDiffChange
+
+	constructor(change: StructuredDiffChange) {
+		super(() => {
+			return cleanupDiffLines(change.content)
+		})
+		this._change = change
+	}
+
+	/**
+	 * Has this diff line's content been addedd?
+	 */
+	get added(): boolean {
+		return !!this._change.add
+	}
+
+	/**
+	 * Has this diff line's content been removed?
+	 */
+	get removed(): boolean {
+		return this._change.type === "del"
+	}
+
+	/**
+	 * Has this diff line's content been changed (added or removed)?
+	 */
+	get changed(): boolean {
+		return this._change.type !== "normal"
+	}
+
+	/**
+	 * Is this diff line's content unchanged?
+	 */
+	get unchanged(): boolean {
+		return this._change.type === "normal"
+	}
+
+	/**
+	 * What is the line number before the change?
+	 */
+	get lineNumberBefore(): number | null {
+		if (this._change.del) {
+			return this._change.ln
+		} else if (this._change.add) {
+			return null
+		} else {
+			return this._change.ln2
+		}
+	}
+
+	/**
+	 * What is the line number after the change?
+	 */
+	get lineNumberAfter(): number | null {
+		if (this._change.del) {
+			return null
+		} else if (this._change.add) {
+			return this._change.ln
+		} else {
+			return this._change.ln2
+		}
+	}
+}

--- a/src/File.ts
+++ b/src/File.ts
@@ -10,6 +10,7 @@ function getGitMatchResult(filePath: string): GitMatchResult {
 export default class File extends FileState {
 	constructor(relativeFilePath: string) {
 		super(
+			"after",
 			relativeFilePath,
 			(): Promise<string> => {
 				return execStdout("git", ["show", `${danger.git.head}:${relativeFilePath}`])
@@ -68,7 +69,7 @@ export default class File extends FileState {
 		if (this.created) {
 			return null
 		} else {
-			return new FileState(this.path, () => {
+			return new FileState("before", this.path, () => {
 				return execStdout("git", ["show", `${danger.git.base}:${this.path}`])
 			})
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,12 @@ import type Context from "./Context"
 import type Rule from "./Rule"
 import type Line from "./Line"
 import type Commit from "./Commit"
+import type DiffLine from "./DiffLine"
+
+export type StructuredDiffChangeType = "add" | "del" | "normal"
 
 export interface StructuredDiffBaseChange {
-	type: "add" | "del" | "normal"
+	type: StructuredDiffChangeType
 	add: true | undefined
 	del: true | undefined
 	normal: true | undefined
@@ -85,7 +88,7 @@ export type ReportKind = "warn" | "fail" | "message"
 
 export interface ReportLocation {
 	file?: File
-	line?: Line
+	line?: Line | DiffLine
 }
 
 export interface Report {


### PR DESCRIPTION
- [Breaking] Updates `Diff` to return `DiffLine` instead of `Line` in all cases
- Adds `DiffLine` (this does not extend `Line`)
- `FileState#lines({ before, after })` is now stricter on DiffLines
- Updates reporting to use the first line of a file if no line is provided (https://github.com/discord/endanger/issues/7)