### PR TITLE
Fix files.matches not working when it's a directory match

### DIFF
--- a/src/utils/matches.ts
+++ b/src/utils/matches.ts
@@ -7,13 +7,9 @@ export default function matches(paths: string[], patterns: string[]): string[] {
 	//     path=some_directory/File.tsx
 	//     pattern=some_directory/**/*
 	// We ignore patterns with subdirectories for now, pending resolution of https://github.com/micromatch/picomatch/issues/89
-	let hasBasename = false
-	let hasNested = false
-	for (const pattern of patterns) {
-		const isBasename = path.basename(pattern) === pattern
-		hasBasename ||= isBasename
-		hasNested ||= !isBasename
-	}
+
+	let hasBasename = patterns.find((pattern) => path.basename(pattern) === pattern) != null
+	let hasNested = patterns.find((pattern) => path.basename(pattern) !== pattern) != null
 
 	if (hasBasename && hasNested) {
 		console.warn(

--- a/src/utils/matches.ts
+++ b/src/utils/matches.ts
@@ -2,6 +2,11 @@ import path from "path"
 import micromatch from "micromatch"
 
 export default function matches(paths: string[], patterns: string[]): string[] {
+	// https://github.com/micromatch/micromatch/#options implies that `basename` only applies to patterns without slashes
+	// However, that doesn't seem to be the case in practice; this means that files.matches does not match when
+	//     path=some_directory/File.tsx
+	//     pattern=some_directory/**/*
+	// We ignore patterns with subdirectories for now, pending resolution of https://github.com/micromatch/picomatch/issues/89
 	const isBasename = patterns.every((pattern) => path.basename(pattern) === pattern)
 	return micromatch(paths, patterns, {
 		basename: isBasename,

--- a/src/utils/matches.ts
+++ b/src/utils/matches.ts
@@ -21,6 +21,6 @@ export default function matches(paths: string[], patterns: string[]): string[] {
 		)
 	}
 	return micromatch(paths, patterns, {
-		basename: hasBasename,
+		basename: hasBasename && !hasNested,
 	})
 }

--- a/src/utils/matches.ts
+++ b/src/utils/matches.ts
@@ -7,8 +7,20 @@ export default function matches(paths: string[], patterns: string[]): string[] {
 	//     path=some_directory/File.tsx
 	//     pattern=some_directory/**/*
 	// We ignore patterns with subdirectories for now, pending resolution of https://github.com/micromatch/picomatch/issues/89
-	const isBasename = patterns.every((pattern) => path.basename(pattern) === pattern)
+	let hasBasename = false
+	let hasNested = false
+	for (const pattern of patterns) {
+		const isBasename = path.basename(pattern) === pattern
+		hasBasename ||= isBasename
+		hasNested ||= !isBasename
+	}
+
+	if (hasBasename && hasNested) {
+		console.warn(
+			"Warning: Potentially misconfigured rule. `matches` can only handle patterns that are all a bare basename (`*.js`) or all nested (`x/**/*.js`).",
+		)
+	}
 	return micromatch(paths, patterns, {
-		basename: isBasename,
+		basename: hasBasename,
 	})
 }

--- a/src/utils/matches.ts
+++ b/src/utils/matches.ts
@@ -1,7 +1,9 @@
+import path from "path"
 import micromatch from "micromatch"
 
 export default function matches(paths: string[], patterns: string[]): string[] {
+	const isBasename = patterns.every((pattern) => path.basename(pattern) === pattern)
 	return micromatch(paths, patterns, {
-		basename: true,
+		basename: isBasename,
 	})
 }


### PR DESCRIPTION
`files.matches` no longer works when the pattern is `some_directory/**/*`, when the `basename` option is true. Patterns with `*.js` still work fine.

This seems to be an issue with the underlying micromatch/picomatch implementation: https://github.com/micromatch/picomatch/issues/89. My expectation is that when the pattern has a slash, `basename` should be ignored. No response to that issue though, so throwing a bandaid onto it to make our existing rules work again.