### PR TITLE
removing line break on message

### DIFF
--- a/src/utils/formatReport.ts
+++ b/src/utils/formatReport.ts
@@ -119,5 +119,5 @@ export default function formatReport(report: Report) {
 		}),
 	)
 
-	return formatted
+	return formatted.replace(/\n$/, '')
 }

--- a/src/utils/formatReport.ts
+++ b/src/utils/formatReport.ts
@@ -119,5 +119,5 @@ export default function formatReport(report: Report) {
 		}),
 	)
 
-	return formatted.replace(/\n$/, '')
+	return formatted.trim()
 }


### PR DESCRIPTION
As mentioned here https://github.com/discord/endanger/issues/16, I'm removing the trailing newline by adding a replace on a newline just before the end of the line.